### PR TITLE
Remove `bottle :unneeded` since it was deprecated

### DIFF
--- a/hostctl.rb
+++ b/hostctl.rb
@@ -6,7 +6,6 @@ class Hostctl < Formula
   desc "Your dev tool to manage /etc/hosts like a pro"
   homepage "https://github.com/guumaster/hostctl"
   version "1.1.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
`brew install` or `upgrade` will shows:
```
==> Installing hostctl from guumaster/tap
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the guumaster/tap tap (not Homebrew/brew or Homebrew/core):
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/guumaster/homebrew-tap/hostctl.rb:9
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the guumaster/tap tap (not Homebrew/brew or Homebrew/core):
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/guumaster/homebrew-tap/hostctl.rb:9
```

Refer to https://github.com/goreleaser/goreleaser/pull/2591 for information.